### PR TITLE
Make image_link regex non-greedy

### DIFF
--- a/m2r.py
+++ b/m2r.py
@@ -80,7 +80,7 @@ class RestBlockLexer(mistune.BlockLexer):
 
 class RestInlineGrammar(mistune.InlineGrammar):
     image_link = re.compile(
-        r'\[!\[(?P<alt>.*?)\]\((?P<url>.*?)\).*\]\((?P<target>.*?)\)'
+        r'\[!\[(?P<alt>.*?)\]\((?P<url>.*?)\).*?\]\((?P<target>.*?)\)'
     )
     rest_role = re.compile(r':.*?:`.*?`|`[^`]+`:.*?:')
     rest_link = re.compile(r'`[^`]*?`_')


### PR DESCRIPTION
In case there is more than one image link on the same line, the original regex would consume all of them.