### PR TITLE
imported missing references to ErrorString and SafeString

### DIFF
--- a/m2r.py
+++ b/m2r.py
@@ -8,6 +8,8 @@ from argparse import ArgumentParser, Namespace, ArgumentError
 
 from docutils import statemachine, nodes, io, utils
 from docutils.parsers import rst
+from docutils.core import ErrorString
+from docutils.utils import SafeString
 import mistune
 
 


### PR DESCRIPTION
As pointed out by cclauss [here](https://github.com/reinforceio/tensorforce/issues/23).