### PR TITLE
ENH: add anonymous_references option

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,6 +50,7 @@ templates_path = ['_templates']
 source_suffix = '.md'
 no_underscore_emphasis = True
 m2r_parse_relative_links = True
+m2r_anonymous_references = False
 
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'

--- a/m2r.py
+++ b/m2r.py
@@ -44,6 +44,9 @@ parser.add_argument('--no-underscore-emphasis', action='store_true',
 parser.add_argument('--parse-relative-links', action='store_true',
                     default=False,
                     help='parse relative links into ref or doc directives')
+parser.add_argument('--anonymous-references', action='store_true',
+                    default=False,
+                    help='use anonymous references in generated rst')
 
 
 def parse_options():
@@ -191,11 +194,14 @@ class RestRenderer(mistune.Renderer):
 
     def __init__(self, *args, **kwargs):
         self.parse_relative_links = kwargs.pop('parse_relative_links', False)
+        self.anonymous_references = kwargs.pop('anonymous_references', False)
         super(RestRenderer, self).__init__(*args, **kwargs)
         if not _is_sphinx:
             parse_options()
             if options.parse_relative_links:
                 self.parse_relative_links = options.parse_relative_links
+            if options.anonymous_references:
+                self.anonymous_references = options.anonymous_references
 
     def _indent_block(self, block):
         return '\n'.join(self.indent + line if line else ''
@@ -364,6 +370,10 @@ class RestRenderer(mistune.Renderer):
         :param title: title content for `title` attribute.
         :param text: text content for description.
         """
+        if self.anonymous_references:
+            underscore = '__'
+        else:
+            underscore = '_'
         if title:
             return self._raw_html(
                 '<a href="{link}" title="{title}">{text}</a>'.format(
@@ -371,13 +381,18 @@ class RestRenderer(mistune.Renderer):
                 )
             )
         if not self.parse_relative_links:
-            return '\ `{text} <{target}>`_\ '.format(target=link, text=text)
+            return '\ `{text} <{target}>`{underscore}\ '.format(
+                target=link,
+                text=text,
+                underscore=underscore
+            )
         else:
             url_info = urlparse(link)
             if url_info.scheme:
-                return '\ `{text} <{target}>`_\ '.format(
+                return '\ `{text} <{target}>`{underscore}\ '.format(
                     target=link,
-                    text=text
+                    text=text,
+                    underscore=underscore
                 )
             else:
                 link_type = 'doc'
@@ -604,6 +619,7 @@ def setup(app):
     _is_sphinx = True
     app.add_config_value('no_underscore_emphasis', False, 'env')
     app.add_config_value('m2r_parse_relative_links', False, 'env')
+    app.add_config_value('m2r_anonymous_references', False, 'env')
     app.add_source_parser('.md', M2RParser)
     app.add_directive('mdinclude', MdInclude)
     metadata = dict(

--- a/m2r.py
+++ b/m2r.py
@@ -543,7 +543,8 @@ class M2RParser(rst.Parser, object):
         config = document.settings.env.config
         converter = M2R(
             no_underscore_emphasis=config.no_underscore_emphasis,
-            parse_relative_links=config.m2r_parse_relative_links
+            parse_relative_links=config.m2r_parse_relative_links,
+            anonymous_references=config.m2r_anonymous_references,
         )
         super(M2RParser, self).parse(converter(inputstring), document)
 
@@ -604,7 +605,8 @@ class MdInclude(rst.Directive):
         config = self.state.document.settings.env.config
         converter = M2R(
             no_underscore_emphasis=config.no_underscore_emphasis,
-            parse_relative_links=config.m2r_parse_relative_links
+            parse_relative_links=config.m2r_parse_relative_links,
+            anonymous_references=config.m2r_anonymous_references,
         )
         include_lines = statemachine.string2lines(converter(rawtext),
                                                   tab_width,

--- a/tests/test.md
+++ b/tests/test.md
@@ -5,3 +5,5 @@
 __content__
 
 ## サブタイトル
+
+[A link to GitHub](http://github.com/)

--- a/tests/test.rst
+++ b/tests/test.rst
@@ -9,3 +9,5 @@ SubTitle
 
 サブタイトル
 ------------
+
+`A link to GitHub <http://github.com/>`_

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,6 +33,7 @@ class TestConvert(TestCase):
         options.overwrite = False
         options.dry_run = False
         options.no_underscore_emphasis = False
+        options.anonymous_references = False
         self._orig_argv = copy(sys.argv)
         if path.exists(test_rst):
             with open(test_rst) as f:
@@ -54,6 +55,7 @@ class TestConvert(TestCase):
             message = buffer.read().decode()
         self.assertIn('usage', message)
         self.assertIn('underscore-emphasis', message)
+        self.assertIn('anonymous-references', message)
         self.assertIn('optional arguments:', message)
 
     def test_parse_file(self):
@@ -122,3 +124,11 @@ class TestConvert(TestCase):
             main()
         self.assertIn('__content__', m.call_args[0][0])
         self.assertNotIn('**content**', m.call_args[0][0])
+
+    def test_anonymous_reference_option(self):
+        sys.argv = [
+            sys.argv[0], '--anonymous-references', '--dry-run', test_md]
+        with patch(_builtin + '.print') as m:
+            main()
+        self.assertIn("`A link to GitHub <http://github.com/>`__",
+                      m.call_args[0][0])

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -142,6 +142,12 @@ class TestInlineMarkdown(RendererTestBase):
         self.assertEqual(
             out, '\nthis is a `link <http://example.com/>`_.\n')
 
+    def test_anonymous_link(self):
+        src = 'this is a [link](http://example.com/).'
+        out = self.conv(src, anonymous_references=True)
+        self.assertEqual(
+            out, '\nthis is a `link <http://example.com/>`__.\n')
+
     def test_link_with_rel_link_enabled(self):
         src = 'this is a [link](http://example.com/).'
         out = self.conv_no_check(
@@ -150,6 +156,16 @@ class TestInlineMarkdown(RendererTestBase):
         )
         self.assertEqual(
             out, '\nthis is a `link <http://example.com/>`_.\n')
+
+    def test_anonymous_link_with_rel_link_enabled(self):
+        src = 'this is a [link](http://example.com/).'
+        out = self.conv_no_check(
+            src,
+            parse_relative_links=True,
+            anonymous_references=True
+        )
+        self.assertEqual(
+            out, '\nthis is a `link <http://example.com/>`__.\n')
 
     def test_anchor(self):
         src = 'this is an [anchor](#anchor).'


### PR DESCRIPTION
This adds an option in m2r to make hyperlinks anonymous; that is, to use two underscores instead of one (see http://docutils.sourceforge.net/docs/user/rst/quickref.html#indirect-hyperlink-targets)

In some RST systems (including sphinx), if you have repeated identical normal style references, it will lead to a warning:

```pytb
WARNING: Duplicate explicit target name: google
```

Setting ``anonymous_references`` from this PR to True will silence this warning.