### PR TITLE
Fix some tiny typos in the docs

### DIFF
--- a/docs/example.md
+++ b/docs/example.md
@@ -145,7 +145,7 @@ The below is reST-style math-block.
 To include markdown file:
 
 ```rest
-.. mdinclude:: path-to-flie.md
+.. mdinclude:: path-to-file.md
 ```
 
 To include markdown file with specific lines:
@@ -164,7 +164,7 @@ Original ``included.md`` file is:
 This file included as:
 
 ```md
-#### Includs this line
+#### Include this line
 ```
 
 and results in HTML as below:

--- a/docs/included.md
+++ b/docs/included.md
@@ -1,5 +1,5 @@
 NOT-INCLUDED
 
-#### Includs this line
+#### Include this line
 
 NOT-INCLUDED


### PR DESCRIPTION
Hey @miyakogi,

Thank you so much for adding the `start-line` and `end-line` options to `mdinclude`, they're EXACTLY what I needed to use this week!

Just fixing up some super small typos in the docs.

Love the module, keep up the great work :smile:

Cheers,
Kyle