### PR TITLE
Add option to disable inline math

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,6 +51,7 @@ source_suffix = '.md'
 no_underscore_emphasis = True
 m2r_parse_relative_links = True
 m2r_anonymous_references = False
+m2r_disable_inline_math = False
 
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'

--- a/m2r.py
+++ b/m2r.py
@@ -143,10 +143,12 @@ class RestInlineLexer(mistune.InlineLexer):
         super(RestInlineLexer, self).__init__(*args, **kwargs)
         if not _is_sphinx:
             parse_options()
-        if no_underscore_emphasis or options.no_underscore_emphasis:
+        if no_underscore_emphasis or \
+         getattr(options, 'no_underscore_emphasis', False):
             self.rules.no_underscore_emphasis()
         inline_maths = 'inline_math' in self.default_rules
-        if disable_inline_math or options.disable_inline_math:
+        if disable_inline_math or \
+         getattr(options, 'disable_inline_math', False):
             if inline_maths:
                 self.default_rules.remove('inline_math')
         elif not inline_maths:
@@ -205,9 +207,9 @@ class RestRenderer(mistune.Renderer):
         super(RestRenderer, self).__init__(*args, **kwargs)
         if not _is_sphinx:
             parse_options()
-            if options.parse_relative_links:
+            if getattr(options, 'parse_relative_links', False):
                 self.parse_relative_links = options.parse_relative_links
-            if options.anonymous_references:
+            if getattr(options, 'anonymous_references', False):
                 self.anonymous_references = options.anonymous_references
 
     def _indent_block(self, block):

--- a/m2r.py
+++ b/m2r.py
@@ -143,12 +143,14 @@ class RestInlineLexer(mistune.InlineLexer):
         super(RestInlineLexer, self).__init__(*args, **kwargs)
         if not _is_sphinx:
             parse_options()
-        if no_underscore_emphasis or \
-         getattr(options, 'no_underscore_emphasis', False):
+        if no_underscore_emphasis or getattr(options,
+                                             'no_underscore_emphasis',
+                                             False):
             self.rules.no_underscore_emphasis()
         inline_maths = 'inline_math' in self.default_rules
-        if disable_inline_math or \
-         getattr(options, 'disable_inline_math', False):
+        if disable_inline_math or getattr(options,
+                                          'disable_inline_math',
+                                          False):
             if inline_maths:
                 self.default_rules.remove('inline_math')
         elif not inline_maths:

--- a/tests/test.md
+++ b/tests/test.md
@@ -7,3 +7,5 @@ __content__
 ## サブタイトル
 
 [A link to GitHub](http://github.com/)
+
+This is `$E = mc^2$` inline math.

--- a/tests/test.rst
+++ b/tests/test.rst
@@ -11,3 +11,5 @@ SubTitle
 ------------
 
 `A link to GitHub <http://github.com/>`_
+
+This is :math:`E = mc^2` inline math.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,6 +34,7 @@ class TestConvert(TestCase):
         options.dry_run = False
         options.no_underscore_emphasis = False
         options.anonymous_references = False
+        options.disable_inline_math = False
         self._orig_argv = copy(sys.argv)
         if path.exists(test_rst):
             with open(test_rst) as f:
@@ -56,6 +57,7 @@ class TestConvert(TestCase):
         self.assertIn('usage', message)
         self.assertIn('underscore-emphasis', message)
         self.assertIn('anonymous-references', message)
+        self.assertIn('inline-math', message)
         self.assertIn('optional arguments:', message)
 
     def test_parse_file(self):
@@ -132,3 +134,11 @@ class TestConvert(TestCase):
             main()
         self.assertIn("`A link to GitHub <http://github.com/>`__",
                       m.call_args[0][0])
+
+    def test_disable_inline_math(self):
+        sys.argv = [
+            sys.argv[0], '--disable-inline-math', '--dry-run', test_md]
+        with patch(_builtin + '.print') as m:
+            main()
+        self.assertIn('``$E = mc^2$``', m.call_args[0][0])
+        self.assertNotIn(':math:', m.call_args[0][0])

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -290,6 +290,11 @@ class TestInlineMarkdown(RendererTestBase):
         out = self.conv(src)
         self.assertEqual(out, '\nthis is :math:`E = mc^2` inline math.\n')
 
+    def test_disable_inline_math(self):
+        src = 'this is `$E = mc^2$` inline math.'
+        out = self.conv(src, disable_inline_math=True)
+        self.assertEqual(out, '\nthis is ``$E = mc^2$`` inline math.\n')
+
     def test_inline_html(self):
         src = 'this is <s>html</s>.'
         out = self.conv(src)


### PR DESCRIPTION
This adds the sphinx option `m2r_disable_inline_math` and the cli option `--disable-inline-math`.

Previously there was no way to disable interpreting anything between two $ characters as math. An example of a problematic document is something like [this](https://github.com/adventuregamestudio/ags-manual/wiki/UpgradeTo335), where we are having rendering issues due to the inline math parsing being triggered by page content.

I've not really looked at anything similar before, so feel free to edit or reject for a different approach.

Thanks!