### PR TITLE
Use reST literal block for Sphinx code block

### DIFF
--- a/m2r.py
+++ b/m2r.py
@@ -228,7 +228,7 @@ class RestRenderer(mistune.Renderer):
         elif lang:
             first_line = '\n.. code-block:: {}\n\n'.format(lang)
         elif _is_sphinx:
-            first_line = '\n.. code-block:: guess\n\n'
+            first_line = '\n::\n\n'
         else:
             first_line = '\n.. code-block::\n\n'
         return first_line + self._indent_block(code) + '\n'


### PR DESCRIPTION
Currently code blocks for Sphinx are passed 'guess' as the code language, which then gets passed to the lexer to highlight the language. Sphinx variable `highlight_language` can set control the default language, but it cannot be used with m2r because value 'guess' has been explicitly set. So effectively, the code-blocks are stuck with 'guess' and cannot be altered.

This change sets Sphinx code blocks as reST literal blocks, which do not have any language specified. With this change, Sphinx config option `highlight_language` can manage code highlighting (and can be set to 'guess' if desired).

Details for `highlight_language` are [here](http://www.sphinx-doc.org/en/master/usage/configuration.html#confval-highlight_language), with further details [here](http://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#code-examples).
Details of the literal block are [here](http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#literal-blocks).

Thanks!