### PR TITLE
Remove a trailing newline after .rst directives (fix issue #35)

### DIFF
--- a/m2r.py
+++ b/m2r.py
@@ -507,7 +507,7 @@ class RestRenderer(mistune.Renderer):
         return marker
 
     def directive(self, text):
-        return '\n' + text + '\n'
+        return '\n' + text
 
     def rest_code_block(self):
         return '\n\n'


### PR DESCRIPTION
As per #35, remove a trailing newline in a `directive` method to fix a conversion error with multi-line `.rst`/Sphinx directives, such as `toctree`.

I've done a quick tested with single-line directives too, and those appeared good, but for reference I'm not as fluent in reStructuredText as I am in Markdown.