### PR TITLE
ENH: Use add_source_suffix if available

### DIFF
--- a/m2r.py
+++ b/m2r.py
@@ -220,7 +220,7 @@ class RestRenderer(mistune.Renderer):
 
     def _raw_html(self, html):
         self._include_raw_html = True
-        return '\ :raw-html-m2r:`{}`\ '.format(html)
+        return r'\ :raw-html-m2r:`{}`\ '.format(html)
 
     def block_code(self, code, lang=None):
         if lang == 'math':
@@ -323,14 +323,14 @@ class RestRenderer(mistune.Renderer):
 
         :param text: text content for emphasis.
         """
-        return '\ **{}**\ '.format(text)
+        return r'\ **{}**\ '.format(text)
 
     def emphasis(self, text):
         """Rendering *emphasis* text.
 
         :param text: text content for emphasis.
         """
-        return '\ *{}*\ '.format(text)
+        return r'\ *{}*\ '.format(text)
 
     def codespan(self, text):
         """Rendering inline `code` text.
@@ -338,7 +338,7 @@ class RestRenderer(mistune.Renderer):
         :param text: text content for inline code.
         """
         if '``' not in text:
-            return '\ ``{}``\ '.format(text)
+            return r'\ ``{}``\ '.format(text)
         else:
             # actually, docutils split spaces in literal
             return self._raw_html(
@@ -392,7 +392,7 @@ class RestRenderer(mistune.Renderer):
                 )
             )
         if not self.parse_relative_links:
-            return '\ `{text} <{target}>`{underscore}\ '.format(
+            return r'\ `{text} <{target}>`{underscore}\ '.format(
                 target=link,
                 text=text,
                 underscore=underscore
@@ -400,7 +400,7 @@ class RestRenderer(mistune.Renderer):
         else:
             url_info = urlparse(link)
             if url_info.scheme:
-                return '\ `{text} <{target}>`{underscore}\ '.format(
+                return r'\ `{text} <{target}>`{underscore}\ '.format(
                     target=link,
                     text=text,
                     underscore=underscore
@@ -422,7 +422,7 @@ class RestRenderer(mistune.Renderer):
                     doc_name=os.path.splitext(url_info.path)[0],
                     anchor=anchor
                 )
-                return '\ :{link_type}:`{text} <{doc_link}>`\ '.format(
+                return r'\ :{link_type}:`{text} <{doc_link}>`\ '.format(
                     link_type=link_type,
                     doc_link=doc_link,
                     text=text
@@ -462,7 +462,7 @@ class RestRenderer(mistune.Renderer):
         :param key: identity key for the footnote.
         :param index: the index count of current footnote.
         """
-        return '\ [#fn-{}]_\ '.format(key)
+        return r'\ [#fn-{}]_\ '.format(key)
 
     def footnote_item(self, key, text):
         """Rendering a footnote item.
@@ -500,7 +500,7 @@ class RestRenderer(mistune.Renderer):
 
     def inline_math(self, math):
         """Extension of recommonmark"""
-        return '\ :math:`{}`\ '.format(math)
+        return r'\ :math:`{}`\ '.format(math)
 
     def eol_literal_marker(self, marker):
         """Extension of recommonmark"""
@@ -605,7 +605,7 @@ class MdInclude(rst.Directive):
             include_file = io.FileInput(source_path=path,
                                         encoding=encoding,
                                         error_handler=e_handler)
-        except UnicodeEncodeError as error:
+        except UnicodeEncodeError:
             raise self.severe('Problems with "%s" directive path:\n'
                               'Cannot encode input file path "%s" '
                               '(wrong locale?).' %

--- a/m2r.py
+++ b/m2r.py
@@ -650,7 +650,8 @@ def setup(app):
     app.add_config_value('m2r_anonymous_references', False, 'env')
     app.add_config_value('m2r_disable_inline_math', False, 'env')
     if hasattr(app, 'add_source_suffix'):
-        app.add_source_suffix('.md', M2RParser)
+        app.add_source_suffix('.md', 'markdown')
+        app.add_source_parser(M2RParser)
     else:
         app.add_source_parser('.md', M2RParser)
     app.add_directive('mdinclude', MdInclude)

--- a/m2r.py
+++ b/m2r.py
@@ -649,7 +649,10 @@ def setup(app):
     app.add_config_value('m2r_parse_relative_links', False, 'env')
     app.add_config_value('m2r_anonymous_references', False, 'env')
     app.add_config_value('m2r_disable_inline_math', False, 'env')
-    app.add_source_parser('.md', M2RParser)
+    if hasattr(app, 'add_source_suffix'):
+        app.add_source_suffix('.md', M2RParser)
+    else:
+        app.add_source_parser('.md', M2RParser)
     app.add_directive('mdinclude', MdInclude)
     metadata = dict(
         version=__version__,

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -77,7 +77,7 @@ class TestBasic(RendererTestBase):
         out = self.conv(src)
         self.assertEqual(
             out,
-            prolog + '\nabc def\ :raw-html-m2r:`<br>`\nghi' + '\n',
+            prolog + '\nabc def\\ :raw-html-m2r:`<br>`\nghi' + '\n',
         )
 
 
@@ -244,7 +244,7 @@ class TestInlineMarkdown(RendererTestBase):
         out = self.conv(src)
         self.assertEqual(
             out,
-            '\na co:\ ``de`` and `RefLink <http://example.com>`_ here.\n',
+            '\na co:\\ ``de`` and `RefLink <http://example.com>`_ here.\n',
         )
 
     def test_rest_role_incomplete2(self):
@@ -252,7 +252,7 @@ class TestInlineMarkdown(RendererTestBase):
         out = self.conv(src)
         self.assertEqual(
             out,
-            '\na `RefLink <http://example.com>`_ and co:\ ``de`` here.\n',
+            '\na `RefLink <http://example.com>`_ and co:\\ ``de`` here.\n',
         )
 
     def test_rest_role_with_code(self):
@@ -704,8 +704,8 @@ class TestFootNote(RendererTestBase):
         out = self.conv(src)
         self.assertEqual(out, '\n'.join([
             '',
-            'This is a\ [#fn-1]_ '
-            'footnote\ [#fn-2]_ ref\ [#fn-ref]_ with rst [#a]_.',
+            'This is a\\ [#fn-1]_ '
+            'footnote\\ [#fn-2]_ ref\\ [#fn-ref]_ with rst [#a]_.',
             '',
             '.. [#a] note rst',  # one empty line inserted...
             '',


### PR DESCRIPTION
`add_source_parser` was repurposed in https://github.com/sphinx-doc/sphinx/pull/4594 (Sphinx 1.8). In Sphinx 2, it began emitting a `RemovedInSphinx30Warning` (as noted in #34). This patch looks for `add_source_suffix` and uses it if possible. This maintains compatibility with Sphinx < 1.8.

Fixes #34.