### PR TITLE
Adding support for sphinx-style directives on mdinclude

### DIFF
--- a/docs/example.md
+++ b/docs/example.md
@@ -142,13 +142,13 @@ The below is reST-style math-block.
 
 ### Include Markdown file
 
-To include markdown file:
+To include a markdown file:
 
 ```rest
 .. mdinclude:: path-to-file.md
 ```
 
-To include markdown file with specific lines:
+To include a markdown file with a specific start and end line:
 
 ```rest
 .. mdinclude:: included.md
@@ -156,22 +156,60 @@ To include markdown file with specific lines:
    :end-line: -2
 ```
 
-Original ``included.md`` file is:
+The original ``included.md`` file is:
 
 .. include:: included.md
    :code: md
 
-This file included as:
+This file is included as:
 
 ```md
 #### Include this line
 ```
 
-and results in HTML as below:
+and the results in HTML are as shown below:
 
 .. mdinclude:: included.md
    :start-line: 2
    :end-line: -2
+
+To include a markdown file with specific line ranges:
+
+```rest
+.. mdinclude:: line_inclusion.md
+   :lines: 1, 3-4, 7-
+```
+
+The original ``line_inclusion.md`` file is:
+
+.. include:: line_inclusion.md
+   :code: md
+
+And the resulting HTML output is:
+
+.. mdinclude:: line_inclusion.md
+   :lines: 1, 3-4, 7-
+
+
+To include a markdown file by specific text:
+
+```rest
+.. mdinclude:: text_inclusion.md
+   :start-after: Start Here
+   :end-before: End Here
+```
+
+The original ``text_inclusion.md`` file is:
+
+.. include:: text_inclusion.md
+   :code: md
+
+And the resulting HTML output is:
+
+.. mdinclude:: text_inclusion.md
+   :start-after: Start Here
+   :end-before: End Here
+
 
 ### Footnote
 

--- a/docs/line_inclusion.md
+++ b/docs/line_inclusion.md
@@ -1,0 +1,9 @@
+#### Include
+#### Skip
+#### Include
+#### Include
+#### Skip
+#### Skip
+#### Include
+#### Include
+#### Include

--- a/docs/text_inclusion.md
+++ b/docs/text_inclusion.md
@@ -1,0 +1,14 @@
+#### Skip
+#### Skip
+
+#### Start Here
+#### Include
+
+#### Include
+#### Include
+#### Include
+#### End Here (Skip)
+
+#### Skip
+#### Skip
+#### Skip

--- a/m2r.py
+++ b/m2r.py
@@ -659,9 +659,9 @@ class MdInclude(rst.Directive):
                              for number in line_range.split('-', 1)]
                 if len(endpoints) > 1:
                     keep_line_ranges.update(
-                        set(range(endpoints[0], endpoints[1]+1)))
+                        set(range(endpoints[0]-1, endpoints[1])))
                 else:
-                    keep_line_ranges.add(endpoints[0])
+                    keep_line_ranges.add(endpoints[0]-1)
             keep = keep.intersection(keep_line_ranges)
 
         lines = [lines[i] for i in sorted(keep)]

--- a/m2r.py
+++ b/m2r.py
@@ -58,17 +58,17 @@ def parse_options():
 
 class RestBlockGrammar(mistune.BlockGrammar):
     directive = re.compile(
-            r'^( *\.\..*?)\n(?=\S)',
-            re.DOTALL | re.MULTILINE,
-        )
+        r'^( *\.\..*?)\n(?=\S)',
+        re.DOTALL | re.MULTILINE,
+    )
     oneline_directive = re.compile(
-            r'^( *\.\..*?)$',
-            re.DOTALL | re.MULTILINE,
-        )
+        r'^( *\.\..*?)$',
+        re.DOTALL | re.MULTILINE,
+    )
     rest_code_block = re.compile(
-            r'^::\s*$',
-            re.DOTALL | re.MULTILINE,
-        )
+        r'^::\s*$',
+        re.DOTALL | re.MULTILINE,
+    )
 
 
 class RestBlockLexer(mistune.BlockLexer):
@@ -483,6 +483,7 @@ class RestRenderer(mistune.Renderer):
             return ''
 
     """Below outputs are for rst."""
+
     def image_link(self, url, target, alt):
         return '\n'.join([
             '',
@@ -575,6 +576,9 @@ class MdInclude(rst.Directive):
     option_spec = {
         'start-line': int,
         'end-line': int,
+        'lines': str,
+        'start-after': str,
+        'end-before': str,
     }
 
     def run(self):
@@ -614,18 +618,54 @@ class MdInclude(rst.Directive):
             raise self.severe('Problems with "%s" directive path:\n%s.' %
                               (self.name, ErrorString(error)))
 
-        # read from the file
-        startline = self.options.get('start-line', None)
-        endline = self.options.get('end-line', None)
+        # get all of the lines and reduce as needed
         try:
-            if startline or (endline is not None):
-                lines = include_file.readlines()
-                rawtext = ''.join(lines[startline:endline])
-            else:
-                rawtext = include_file.read()
+            lines = include_file.readlines()
+            line_count = len(lines)
         except UnicodeError as error:
             raise self.severe('Problem with "%s" directive:\n%s' %
                               (self.name, ErrorString(error)))
+
+        # read from the file
+        start_line = self.options.get('start-line', 1) - 1
+        end_line = self.options.get('end-line', line_count)
+        line_ranges = self.options.get('lines', None)
+        start_marker = self.options.get('start-after', None)
+        end_marker = self.options.get('end-before', None)
+
+        if start_marker:
+            for i, line in enumerate(lines[start_line:end_line], start_line):
+                if start_marker in line:
+                    if i > start_line:
+                        start_line = i
+                    break
+            if i == len(lines):
+                start_line = i
+
+        if end_marker:
+            for i, line in enumerate(lines[start_line:end_line], start_line):
+                if end_marker in line:
+                    if i < end_line:
+                        end_line = i
+                    break
+
+        keep = set(range(start_line, end_line))
+
+        if line_ranges:
+            keep_line_ranges = set()
+            line_range_list = line_ranges.split(',')
+            for line_range in line_range_list:
+                endpoints = [int(number) if len(number) else len(lines)
+                             for number in line_range.split('-', 1)]
+                if len(endpoints) > 1:
+                    keep_line_ranges.update(
+                        set(range(endpoints[0], endpoints[1]+1)))
+                else:
+                    keep_line_ranges.add(endpoints[0])
+            keep = keep.intersection(keep_line_ranges)
+
+        lines = [lines[i] for i in sorted(keep)]
+        rawtext = ''.join(lines)
 
         config = self.state.document.settings.env.config
         converter = M2R(


### PR DESCRIPTION
Closes #39 

Hi, great project! I made an attempt to address the issue linked above without breaking the existing functionality. Please note, I did not add any tests yet for this PR as I wasn't sure how you were testing the existing `start-line` and `end-line` directives, but I would be happy to add tests with a bit more direction.

The purpose of this PR is to allow users such as myself to include parts of markdown files based on the same syntax that [sphinx uses for its literalinclude](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html?highlight=start-after#directive-literalinclude).

I took some effort to not disrupt the existing `start-line` and `end-line` directives so as not to break backward compatibility. I accomplish this by allowing the user to specify these directives as well as `lines`, `start-before`, and `end-after`. The end result is to take the intersection of all of these directives. For a simple example, if you ask to start on line 5 with a `start-line` directive and then place a `start-after` that first matches line 10, then the lines 5-9 will not be included in the output. I can provide more examples if this is not clear.

Please let me know if there are any changes I can do to make this code more compatible with the rest of the project including testing, documentation, appropriate styling (sorry, my IDE made some whitespace changes it looks like), etc.