### PR TITLE
[fix] TypeError coming from suffix arg removed from sphinx v3.0.0

### DIFF
--- a/m2r.py
+++ b/m2r.py
@@ -649,11 +649,11 @@ def setup(app):
     app.add_config_value('m2r_parse_relative_links', False, 'env')
     app.add_config_value('m2r_anonymous_references', False, 'env')
     app.add_config_value('m2r_disable_inline_math', False, 'env')
-    if hasattr(app, 'add_source_suffix'):
+    try:
+        app.add_source_parser('.md', M2RParser)  # for older sphinx versions
+    except TypeError:
         app.add_source_suffix('.md', 'markdown')
         app.add_source_parser(M2RParser)
-    else:
-        app.add_source_parser('.md', M2RParser)
     app.add_directive('mdinclude', MdInclude)
     metadata = dict(
         version=__version__,


### PR DESCRIPTION
[Since 1.8.0, the suffix argument for app.add_source_parser() has been deprecated. And it is removed now.](https://github.com/sphinx-doc/sphinx/issues/7420#issuecomment-609814898)

Fix and mantain backwards compatibility for older sphinx versions. 

Closes #51 