### PR TITLE
Make TestConvert.test_no_file work with Python 3.10

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,7 +58,7 @@ class TestConvert(TestCase):
         self.assertIn('underscore-emphasis', message)
         self.assertIn('anonymous-references', message)
         self.assertIn('inline-math', message)
-        self.assertIn('optional arguments:', message)
+        self.assertRegex(message, r'option(s|al arguments):')
 
     def test_parse_file(self):
         output = parse_from_file(test_md)


### PR DESCRIPTION
`argparse` in Python 3.10 now prints `options:` instead of `optional arguments:`, see: https://bugs.python.org/issue9694