### PR TITLE
Compatibility fixes for docutils, mistune, argparse

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,20 +3,18 @@ dist: xenial
 
 matrix:
   include:
-    - python: 2.7
-      env: TOXENV=py
-    - python: 3.4
-      env: TOXENV=py
-    - python: 3.5
-      env: TOXENV=py
-    - python: 3.6
-      env: TOXENV=py
     - python: 3.7
       env: TOXENV=py,flake8,sphinx-dev,codecov
+    - python: 3.8
+      env: TOXENV=py,flake8,sphinx-dev,codecov
+    - python: 3.9
+      env: TOXENV=py,flake8,sphinx-dev,codecov
+    - python: 3.10
+      env: TOXENV=py,flake8,sphinx-dev,codecov
     - python: pypy
-      env: TOXENV=py
+      env: TOXENV=py,flake8,sphinx-dev,codecov
     - python: pypy3
-      env: TOXENV=py
+      env: TOXENV=py,flake8,sphinx-dev,codecov
 
 install:
   - pip install tox

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## Version 0.3.0
 
+* Drop support for Python 2.7, 3.4, 3.5, and 3.6
+* Add compatibility with docutils 0.19
+* Sync up assertion with changes in argparse
+
 ### Version 0.2.1 (2018-10-12)
 
 * Add `--disable-inline-math` and `m2r_disable_inline_math` sphinx option

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 * Drop support for Python 2.7, 3.4, 3.5, and 3.6
 * Add compatibility with docutils 0.19
 * Sync up assertion with changes in argparse
+* Limit mistune dependency version range
 
 ### Version 0.2.1 (2018-10-12)
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ a code block in HTML like `see <code>ref</code>_`, which is not expected.
 
 ## Installation
 
-Python 2.7 or Python 3.4+ is required.
+Python 3.7+ is required.
 
 ```
 pip install m2r

--- a/m2r.py
+++ b/m2r.py
@@ -5,21 +5,13 @@ from __future__ import print_function, unicode_literals
 import os
 import os.path
 import re
-import sys
 from argparse import ArgumentParser, Namespace
 
 from docutils import statemachine, nodes, io, utils
 from docutils.parsers import rst
-from docutils.core import ErrorString
-from docutils.utils import SafeString, column_width
+from docutils.utils import column_width
 import mistune
-
-if sys.version_info < (3, ):
-    from codecs import open as _open
-    from urlparse import urlparse
-else:
-    _open = open
-    from urllib.parse import urlparse
+from urllib.parse import urlparse
 
 __version__ = '0.2.1'
 _is_sphinx = False
@@ -609,10 +601,10 @@ class MdInclude(rst.Directive):
             raise self.severe('Problems with "%s" directive path:\n'
                               'Cannot encode input file path "%s" '
                               '(wrong locale?).' %
-                              (self.name, SafeString(path)))
+                              (self.name, path))
         except IOError as error:
             raise self.severe('Problems with "%s" directive path:\n%s.' %
-                              (self.name, ErrorString(error)))
+                              (self.name, io.error_string(error)))
 
         # read from the file
         startline = self.options.get('start-line', None)
@@ -625,7 +617,7 @@ class MdInclude(rst.Directive):
                 rawtext = include_file.read()
         except UnicodeError as error:
             raise self.severe('Problem with "%s" directive:\n%s' %
-                              (self.name, ErrorString(error)))
+                              (self.name, io.error_string(error)))
 
         config = self.state.document.settings.env.config
         converter = M2R(
@@ -670,7 +662,7 @@ def convert(text, **kwargs):
 def parse_from_file(file, encoding='utf-8', **kwargs):
     if not os.path.exists(file):
         raise OSError('No such file exists: {}'.format(file))
-    with _open(file, encoding=encoding) as f:
+    with open(file, encoding=encoding) as f:
         src = f.read()
     output = convert(src, **kwargs)
     return output
@@ -684,7 +676,7 @@ def save_to_file(file, src, encoding='utf-8', **kwargs):
         if confirm.upper() not in ('Y', 'YES'):
             print('skip {}'.format(file))
             return
-    with _open(target, 'w', encoding=encoding) as f:
+    with open(target, 'w', encoding=encoding) as f:
         f.write(src)
 
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ except ImportError:
     with open(readme_file) as f:
         readme = f.read()
 
-install_requires = ['mistune', 'docutils']
+install_requires = ['mistune<2', 'docutils']
 test_requirements = ['pygments']
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import sys
 from os import path
 
 try:
@@ -19,8 +18,6 @@ except ImportError:
 
 install_requires = ['mistune', 'docutils']
 test_requirements = ['pygments']
-if sys.version_info < (3, 3):
-    test_requirements.append('mock')
 
 setup(
     name='m2r',
@@ -42,12 +39,8 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Text Processing',
     ],
     install_requires=install_requires,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,15 +12,8 @@ import subprocess
 
 from m2r import parse_from_file, main, options
 
-if sys.version_info < (3, ):
-    from mock import patch
-    _builtin = '__builtin__'
-    from codecs import open as _open
-    from functools import partial
-    open = partial(_open, encoding='utf-8')
-else:
-    from unittest.mock import patch
-    _builtin = 'builtins'
+from unittest.mock import patch
+_builtin = 'builtins'
 
 curdir = path.dirname(path.abspath(__file__))
 test_md = path.join(curdir, 'test.md')
@@ -58,7 +51,7 @@ class TestConvert(TestCase):
         self.assertIn('underscore-emphasis', message)
         self.assertIn('anonymous-references', message)
         self.assertIn('inline-math', message)
-        self.assertIn('optional arguments:', message)
+        self.assertIn('options:', message)
 
     def test_parse_file(self):
         output = parse_from_file(test_md)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36,37,py,py3},sphinx-dev,flake8
+envlist = py{37,38,39,310,py,py3},sphinx-dev,flake8
 
 [testenv]
 whitelist_externals =


### PR DESCRIPTION
The following compatibility fixes are required to make m2r work with the current Python ecosystem:

- Add compatibility with docutils 0.19 (see commit message for details)

- Require Python 3.7+ due to constraints in docutils 0.19

- Sync up assertion with changes in argparse

- Limit mistune dependency version range ([details](https://github.com/lepture/mistune/issues/291#issuecomment-988652022))
